### PR TITLE
Allow the user to require that FHIR Base URLs use HTTPS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FHIRClient"
 uuid = "b44d2ca2-8176-4fa9-8684-826e17b2a2da"
 authors = ["Dilum Aluthge", "Rhode Island Quality Institute", "contributors"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -3,4 +3,5 @@
     include("unit/fhir-to-julia.jl")
     include("unit/other-fhir-versions.jl")
     include("unit/requests.jl")
+    include("unit/types.jl")
 end

--- a/test/unit/types.jl
+++ b/test/unit/types.jl
@@ -1,1 +1,3 @@
 @test_throws Exception FHIRClient.BaseURL(HTTP.URI("http://example.com"); require_https = true)
+@test FHIRClient.BaseURL(HTTP.URI("http://example.com"); require_https = false) isa FHIRClient.BaseURL
+@test_logs (:warn,) match_mode=:any FHIRClient.BaseURL(HTTP.URI("http://example.com"); require_https = false)

--- a/test/unit/types.jl
+++ b/test/unit/types.jl
@@ -1,0 +1,1 @@
+@test_throws Exception FHIRClient.BaseURL(HTTP.URI("http://example.com"); require_https = true)


### PR DESCRIPTION
Right now, we'll default `require_https` to `false`, so that this PR can be non-breaking.

Then, in the future, we'll make a breaking release of FHIRClient.jl in which we change the default to `require_https = true`.