### PR TITLE
By default, require that FHIR Base URLs use HTTPS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FHIRClient"
 uuid = "b44d2ca2-8176-4fa9-8684-826e17b2a2da"
 authors = ["Dilum Aluthge", "Rhode Island Quality Institute", "contributors"]
-version = "1.2.0"
+version = "2.0.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/types.jl
+++ b/src/types.jl
@@ -38,7 +38,7 @@ struct BaseURL <: Any
 """
 struct BaseURL
     uri::HTTP.URI
-    function BaseURL(uri::HTTP.URI; require_https::Bool = false) # TODO: change the default to `true`
+    function BaseURL(uri::HTTP.URI; require_https::Bool = true)
         this_uri_uses_https = _uses_https(uri)
         if !this_uri_uses_https
             msg = "The following FHIR Base URL does not use HTTPS: $(uri)"


### PR DESCRIPTION
Follow-up to #120 