### PR TITLE
Update to Documenter 1

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,6 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FHIRClient = "b44d2ca2-8176-4fa9-8684-826e17b2a2da"
 Generate = "ff303c0d-e9c7-476c-bf3b-b5f85c44159a"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,7 +19,6 @@ Documenter.makedocs(;
         "API" => "api.md",
         "Auto-generating the type definitions" => "generate.md",
     ],
-    strict=true,
 )
 
 Documenter.deploydocs(;


### PR DESCRIPTION
Docs were broken by Documenter 1 since the `strict` keyword argument is not supported anymore and there was no compat entry for Documenter.