### PR TITLE
Log response body

### DIFF
--- a/src/requests.jl
+++ b/src/requests.jl
@@ -256,17 +256,20 @@ See also [`request_json`](@ref) and [`request_raw`](@ref).
                          headers::AbstractDict = Dict{String, String}(),
                          query::Union{AbstractDict, Nothing} = nothing,
                          require_base_url::Symbol = :strict,
-                         kwargs...)::T where T
+                         kwargs...) where T
     _new_request_body = _write_struct_request_body(body)
-    response_body::String = request_raw(client,
-                                        verb,
-                                        path;
-                                        body = _new_request_body,
-                                        headers = headers,
-                                        query = query,
-                                        require_base_url = require_base_url)::String
-    response_object::T = JSON3.read(response_body,
-                                    T;
-                                    kwargs...)::T
+    response_body = request_raw(client,
+                                verb,
+                                path;
+                                body = _new_request_body,
+                                headers = headers,
+                                query = query,
+                                require_base_url = require_base_url)::String
+    # Default log levels: `@debug` -> -1_000, `@info` -> 0, `@warn` -> 1_000, `@error` -> 2_000
+    # https://docs.julialang.org/en/v1/stdlib/Logging/#Logging.catch_exceptions
+    @logmsg LogLevel(-3_000) "" response_body
+    response_object = JSON3.read(response_body,
+                                 T;
+                                 kwargs...)::T
     return response_object
 end


### PR DESCRIPTION
Sometimes it can be useful to inspect the response body before parsing it with JSON3. Log level -3000 should be sufficient such that you do not fill your logs accidentally.