### PR TITLE
Use public fire.ly server in tests

### DIFF
--- a/test/integration/basic-read.jl
+++ b/test/integration/basic-read.jl
@@ -17,11 +17,11 @@
     ]
     for auth in all_auths
         fhir_version = FHIRClient.R4()
-        base_url = FHIRClient.BaseURL("https://hapi.fhir.org/baseR4")
+        base_url = FHIRClient.BaseURL("https://server.fire.ly/r4")
         client = FHIRClient.Client(fhir_version, base_url, auth)
         @test FHIRClient.get_fhir_version(client) == fhir_version
         @test FHIRClient.get_base_url(client) == base_url
-        search_request_path = "/Patient?given=Jason&family=Argonaut"
+        search_request_path = "/Patient?given=Sam&family=Jones"
         json_response_search_results_bundle = FHIRClient.request_json(client, "GET", search_request_path)
         patient_id = json_response_search_results_bundle.entry[1].resource.id
         patient_request = "/Patient/$(patient_id)"
@@ -38,11 +38,9 @@
         for patient in patients
             @test patient isa FHIRClient.R4Types.AbstractResource
             @test patient isa FHIRClient.R4Types.Patient
-            @test only(patient.name).use == "usual"
-            @test only(patient.name).text == "Jason Argonaut"
-            @test only(patient.name).family == "Argonaut"
-            @test only(only(patient.name).given) == "Jason"
-            @test patient.birthDate == Dates.Date("1985-08-01")
+            @test only(patient.name).family == "Jones"
+            @test only(only(patient.name).given) == "Sam"
+            @test patient.birthDate == Dates.Date("1988-03-04")
         end
         Base.shred!(auth)
         Base.shred!(client)

--- a/test/integration/json.jl
+++ b/test/integration/json.jl
@@ -1,10 +1,10 @@
 @testset "Raw JSON" begin
     for trailing_slash in (true, false)
         fhir_version = FHIRClient.R4()
-        base_url = FHIRClient.BaseURL("https://hapi.fhir.org/baseR4" * (trailing_slash ? "/" : ""))
+        base_url = FHIRClient.BaseURL("https://server.fire.ly/r4" * (trailing_slash ? "/" : ""))
         auth = FHIRClient.AnonymousAuth()
         client = FHIRClient.Client(fhir_version, base_url, auth)
-        search_request = "/Patient?given=Jason&family=Argonaut"
+        search_request = "/Patient?given=Sam&family=Jones"
         json_response_search_results_bundle = FHIRClient.request_json(client, "GET", search_request)
 
         patient_id = json_response_search_results_bundle.entry[1].resource.id
@@ -39,7 +39,7 @@
         end
 
         # Absolute path
-        path = string(base_url.uri) * "/Patient/$(patient_id)"
+        path = string(base_url.uri, trailing_slash ? "" : "/", "Patient/", patient_id)
         path_uri = URIs.URI(path)
     
         # Mismatch of scheme
@@ -75,7 +75,7 @@
         end
 
         # Mismatch of path
-        base_url2 = FHIRClient.BaseURL(URIs.URI(base_url.uri; path = replace(base_url.uri.path, "/base" => "/")))
+        base_url2 = FHIRClient.BaseURL(URIs.URI(base_url.uri; path = replace(base_url.uri.path, "/r4" => "/baseR4")))
         client2 = FHIRClient.Client(fhir_version, base_url2, auth)
         @test_throws ArgumentError FHIRClient.request_raw(client2, "GET", path)
         @test_throws ArgumentError FHIRClient.request_json(client2, "GET", path)


### PR DESCRIPTION
This PR fixes the (probably temporary) test errors caused by the HAPI FHIR server errors by switching to the public fire.ly server in our tests.

Fixes #134.