### PR TITLE
Restructure test such that it is easier to switch servers

### DIFF
--- a/test/integration/basic-read.jl
+++ b/test/integration/basic-read.jl
@@ -1,4 +1,12 @@
 @testset "Basic reading" begin
+    # Settings of the server and the patient used in the tests below
+    # This has to be updated when switching or adding servers
+    server_base_url = FHIRClient.BaseURL("https://server.fire.ly/r4")
+    server_fhir_version = FHIRClient.R4()
+    patient_given_name = "Sam"
+    patient_family_name = "Jones"
+    patient_birthdate = Dates.Date("1988-03-04")
+
     anonymous_auth = FHIRClient.AnonymousAuth()
     oauth2_auth = FHIRClient.OAuth2()
     FHIRClient.set_token!(oauth2_auth, "helloworld")
@@ -16,14 +24,15 @@
         username_password_auth_2,
     ]
     for auth in all_auths
-        fhir_version = FHIRClient.R4()
-        base_url = FHIRClient.BaseURL("https://server.fire.ly/r4")
-        client = FHIRClient.Client(fhir_version, base_url, auth)
-        @test FHIRClient.get_fhir_version(client) == fhir_version
-        @test FHIRClient.get_base_url(client) == base_url
-        search_request_path = "/Patient?given=Sam&family=Jones"
-        json_response_search_results_bundle =
-            FHIRClient.request_json(client, "GET", search_request_path)
+        client = FHIRClient.Client(server_fhir_version, server_base_url, auth)
+        @test FHIRClient.get_fhir_version(client) == server_fhir_version
+        @test FHIRClient.get_base_url(client) == server_base_url
+        json_response_search_results_bundle = FHIRClient.request_json(
+            client,
+            "GET",
+            "/Patient";
+            query = Dict("given" => patient_given_name, "family" => patient_family_name),
+        )
         patient_id = json_response_search_results_bundle.entry[1].resource.id
         patient_request = "/Patient/$(patient_id)"
         patients = [
@@ -58,14 +67,11 @@
         for patient in patients
             @test patient isa FHIRClient.R4Types.AbstractResource
             @test patient isa FHIRClient.R4Types.Patient
-            @test only(patient.name).family == "Jones"
-            @test only(only(patient.name).given) == "Sam"
-            @test patient.birthDate == Dates.Date("1988-03-04")
+            @test only(patient.name).family == patient_family_name
+            @test only(only(patient.name).given) == patient_given_name
+            @test patient.birthDate == patient_birthdate
         end
         Base.shred!(auth)
         Base.shred!(client)
-    end
-    for i = 1:length(all_auths)
-        Base.shred!(all_auths[i])
     end
 end


### PR DESCRIPTION
I put together this PR as an alternative to #139 to show an approach that could make it easier to switch test servers (#136) without introducing a separate struct and without relying on global definitions in basic-read.jl which IMO would make it a bit less convenient to read and run the tests in that file.

Fixes #136.
Closes #139.