### PR TITLE
Add a `finalize` job to CI as a required status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || github.run_number }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
+  finalize:
+    needs: [format, test, docs]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo format: ${{ needs.format.result }}
+          echo test: ${{ needs.test.result }}
+          echo docs: ${{ needs.docs.result }}
+      - run: exit 1
+        # Make sure that every line (except for the last line) ends in `||`.
+        # Make sure that the last line does NOT end in `||`.
+        if: |
+          (needs.format.result != 'success') ||
+          (needs.test.result != 'success') ||
+          (needs.docs.result != 'success')
   format:
     name: Check format
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a `finalize` job that prints the status of the other CI jobs and is passes if and only if all other jobs are successful. Making this job a requirement will ensure that all tests pass successfully. Moreover, this setup will make it possible to extend or modify the CI tests without changing the required status checks on Github.