### PR TITLE
CI: Don't run CompatHelper on the `docs` project

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -13,4 +13,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'import CompatHelper; CompatHelper.main(; subdirs=["", ".format", "docs", "Generate"])'
+        run: julia -e 'import CompatHelper; CompatHelper.main(; subdirs=["", ".format", "Generate"])'


### PR DESCRIPTION
Otherwise CompatHelper tries to make these PRs to add compat entries for FHIRClient itself: https://github.com/JuliaHealth/FHIRClient.jl/pull/142