### PR TITLE
Set a non-upper-bounded compat entry in the docs project

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,3 +5,4 @@ Generate = "ff303c0d-e9c7-476c-bf3b-b5f85c44159a"
 
 [compat]
 Documenter = "1"
+FHIRClient = ">= 2"


### PR DESCRIPTION
This will silence CompatHelper, but also we don't have to worry about having to keep this field updated whenever we make breaking releases of FHIRClient.