### PR TITLE
[Breaking] Change return type of `_request_raw` to `Vector{UInt8}`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FHIRClient"
 uuid = "b44d2ca2-8176-4fa9-8684-826e17b2a2da"
 authors = ["Dilum Aluthge", "Rhode Island Quality Institute", "contributors"]
-version = "2.3.0"
+version = "3.0.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FHIRClient"
 uuid = "b44d2ca2-8176-4fa9-8684-826e17b2a2da"
 authors = ["Dilum Aluthge", "Rhode Island Quality Institute", "contributors"]
-version = "3.0.0"
+version = "3.0.0-dev"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/requests.jl
+++ b/src/requests.jl
@@ -45,7 +45,7 @@ const _common_docstring_request = """
     )
 
 Perform a request with target `path` and method `verb` (such as `"GET"` or `"POST"`)
-for the FHIR `client`, and return the body of the response as `String`.
+for the FHIR `client`, and return the body of the response as `Vector{UInt8}`.
 
 # Arguments
 
@@ -63,7 +63,7 @@ See also [`request_json`](@ref) and [`request`](@ref).
     query::Union{AbstractDict,Nothing} = nothing,
     require_base_url::Symbol = :strict,
     verbose::Int = 0,
-)::String
+)::Vector{UInt8}
     response = _request_raw_response(
         client,
         verb,
@@ -74,8 +74,7 @@ See also [`request_json`](@ref) and [`request`](@ref).
         require_base_url = require_base_url,
         verbose = verbose,
     )
-    response_body_string::String = String(response.body)::String
-    return response_body_string
+    return response.body
 end
 
 @inline function _request_raw_response(
@@ -180,7 +179,7 @@ See also [`request`](@ref) and [`request_raw`](@ref).
     verbose::Int = 0,
 )
     _new_request_body = _write_json_request_body(body)
-    response_body::String = request_raw(
+    response_body = request_raw(
         client,
         verb,
         path;
@@ -189,7 +188,7 @@ See also [`request`](@ref) and [`request_raw`](@ref).
         query = query,
         require_base_url = require_base_url,
         verbose = verbose,
-    )::String
+    )
     response_json = JSON3.read(response_body)
     return response_json
 end
@@ -242,7 +241,7 @@ See also [`request_json`](@ref) and [`request_raw`](@ref).
         query = query,
         require_base_url = require_base_url,
         verbose = verbose,
-    )::String
+    )
 
     # Recall that the default log levels are:
     #     Error === LogLevel(2_000)

--- a/src/requests.jl
+++ b/src/requests.jl
@@ -105,15 +105,6 @@ function _request_raw(
     return response.body
 end
 
-@inline function _write_json_request_body(body::Nothing)::Nothing
-    return nothing
-end
-
-@inline function _write_json_request_body(body::JSON3.Object)::String
-    body_string::String = JSON3.write(body)::String
-    return body_string
-end
-
 """
     request_json(
         client::Client, verb::AbstractString, path::AbstractString;
@@ -140,7 +131,7 @@ See also [`request`](@ref).
     require_base_url::Symbol = :strict,
     verbose::Int = 0,
 )
-    _new_request_body = _write_json_request_body(body)
+    _new_request_body = body === nothing ? nothing : JSON3.write(body)
     response_body = _request_raw(
         client,
         verb,
@@ -153,15 +144,6 @@ See also [`request`](@ref).
     )
     response_json = JSON3.read(response_body)
     return response_json
-end
-
-@inline function _write_struct_request_body(body::Nothing)::Nothing
-    return nothing
-end
-
-@inline function _write_struct_request_body(body)::String
-    body_string::String = JSON3.write(body)::String
-    return body_string
 end
 
 """
@@ -193,7 +175,7 @@ See also [`request_json`](@ref).
     verbose::Int = 0,
     kwargs...,
 )::T where {T}
-    _new_request_body = _write_struct_request_body(body)
+    _new_request_body = body === nothing ? nothing : JSON3.write(body)
     response_body = _request_raw(
         client,
         verb,

--- a/src/requests.jl
+++ b/src/requests.jl
@@ -38,22 +38,6 @@ const _common_docstring_request = """
   The keyword argument is forwarded to `HTTP.request` and can be set to `1` or `2` for increasingly verbose logging.
 """
 
-"""
-    request_raw(
-        client::Client, verb::AbstractString, path::AbstractString;
-        <keyword arguments>
-    )
-
-Perform a request with target `path` and method `verb` (such as `"GET"` or `"POST"`)
-for the FHIR `client`, and return the body of the response as `Vector{UInt8}`.
-
-# Arguments
-
-- `body::Union{AbstractString, Nothing} = nothing`: body of the request.
-$(_common_docstring_request)
-
-See also [`request_json`](@ref) and [`request`](@ref).
-"""
 @inline function request_raw(
     client::Client,
     verb::AbstractString,
@@ -166,7 +150,7 @@ for the FHIR `client`, and parse the JSON response with JSON3.
 - `body::Union{JSON3.Object, Nothing} = nothing`: JSON body of the request.
 $(_common_docstring_request)
 
-See also [`request`](@ref) and [`request_raw`](@ref).
+See also [`request`](@ref).
 """
 @inline function request_json(
     client::Client,
@@ -217,7 +201,7 @@ for the FHIR `client`, and parse the JSON response with JSON3 as an object of ty
 $(_common_docstring_request)
 - `kwargs...`: remaining keyword arguments that are forwarded to `JSON3.read` for parsing the JSON response.
 
-See also [`request_json`](@ref) and [`request_raw`](@ref).
+See also [`request_json`](@ref).
 """
 @inline function request(
     ::Type{T},

--- a/src/requests.jl
+++ b/src/requests.jl
@@ -38,7 +38,7 @@ const _common_docstring_request = """
   The keyword argument is forwarded to `HTTP.request` and can be set to `1` or `2` for increasingly verbose logging.
 """
 
-@inline function request_raw(
+function _request_raw(
     client::Client,
     verb::AbstractString,
     path::AbstractString;
@@ -48,29 +48,6 @@ const _common_docstring_request = """
     require_base_url::Symbol = :strict,
     verbose::Int = 0,
 )::Vector{UInt8}
-    response = _request_raw_response(
-        client,
-        verb,
-        path;
-        body = body,
-        headers = headers,
-        query = query,
-        require_base_url = require_base_url,
-        verbose = verbose,
-    )
-    return response.body
-end
-
-@inline function _request_raw_response(
-    client::Client,
-    verb::AbstractString,
-    path::AbstractString;
-    body::Union{AbstractString,Nothing} = nothing,
-    headers::AbstractDict = Dict{String,String}(),
-    query::Union{AbstractDict,Nothing} = nothing,
-    require_base_url::Symbol = :strict,
-    verbose::Int = 0,
-)
     # Check that `require_base_url` is valid
     if require_base_url !== :strict &&
        require_base_url !== :host &&
@@ -124,7 +101,8 @@ end
         HTTP.request(verb, full_url, _new_headers, body; query = query, verbose = verbose)
     end
     empty!(_new_headers)
-    return response
+
+    return response.body
 end
 
 @inline function _write_json_request_body(body::Nothing)::Nothing
@@ -163,7 +141,7 @@ See also [`request`](@ref).
     verbose::Int = 0,
 )
     _new_request_body = _write_json_request_body(body)
-    response_body = request_raw(
+    response_body = _request_raw(
         client,
         verb,
         path;
@@ -216,7 +194,7 @@ See also [`request_json`](@ref).
     kwargs...,
 )::T where {T}
     _new_request_body = _write_struct_request_body(body)
-    response_body = request_raw(
+    response_body = _request_raw(
         client,
         verb,
         path;

--- a/src/tryparse.jl
+++ b/src/tryparse.jl
@@ -1,4 +1,4 @@
-function tryparse_json(response_body::AbstractString)
+function tryparse_json(response_body::AbstractVector{UInt8})
     response_json = try
         JSON3.read(response_body)
     catch ex
@@ -8,8 +8,8 @@ function tryparse_json(response_body::AbstractString)
         # `response_body` so that the user can try to figure out why it failed to
         # parse as valid JSON.
         bt = catch_backtrace()
-        @logmsg LogLevel(-1_000) "FHIRClient.tryparse_json()" response_body exception =
-            (ex, bt)
+        @logmsg LogLevel(-1_000) "FHIRClient.tryparse_json()" response_body =
+            String(response_body) exception = (ex, bt)
         nothing
     end
     return response_json

--- a/test/integration/basic-read.jl
+++ b/test/integration/basic-read.jl
@@ -75,7 +75,7 @@
         @testset "verbosity" begin
             request_dict(args...; kwargs...) = FHIRClient.request(Dict, args...; kwargs...)
             search_request_path = "/Patient?given=$patient_given_name&family=$patient_family_name"
-            for f in (FHIRClient.request_raw, FHIRClient.request_json, request_dict)
+            for f in (FHIRClient._request_raw, FHIRClient.request_json, request_dict)
                 # In versions >= 1.0.0, HTTP.jl uses the Julia logging system for verbose information
                 if isdefined(HTTP, :LoggingExtras)
                     # No logs by default and with `verbose = 0`

--- a/test/integration/json.jl
+++ b/test/integration/json.jl
@@ -11,7 +11,7 @@
 
         patient_id = json_response_search_results_bundle.entry[1].resource.id
         patient_request = "/Patient/$(patient_id)"
-        raw_response = @inferred(FHIRClient.request_raw(client, "GET", patient_request))
+        raw_response = @inferred(FHIRClient._request_raw(client, "GET", patient_request))
         @test raw_response isa Vector{UInt8}
 
         # `request_json` and `request` yield consistent results
@@ -37,7 +37,7 @@
         for path in ("Patient/$(patient_id)", "./Patient/$(patient_id)")
             # For relative paths the `require_base_url` setting does not matter
             for sym in (:strict, :host, :scheme, :no)
-                @test FHIRClient.request_raw(client, "GET", path; require_base_url = sym) ==
+                @test FHIRClient._request_raw(client, "GET", path; require_base_url = sym) ==
                       raw_response
                 @test FHIRClient.request_json(
                     client,
@@ -56,7 +56,7 @@
 
             # Invalid keyword arguments
             for sym in (:yes, :host_only, :all)
-                @test_throws ArgumentError FHIRClient.request_raw(
+                @test_throws ArgumentError FHIRClient._request_raw(
                     client,
                     "GET",
                     path;
@@ -88,11 +88,11 @@
             require_https = false,
         )
         client2 = FHIRClient.Client(fhir_version, base_url2, auth)
-        @test_throws ArgumentError FHIRClient.request_raw(client2, "GET", path)
+        @test_throws ArgumentError FHIRClient._request_raw(client2, "GET", path)
         @test_throws ArgumentError FHIRClient.request_json(client2, "GET", path)
         @test_throws ArgumentError FHIRClient.request(Dict, client2, "GET", path)
         for sym in (:strict, :host, :scheme)
-            @test_throws ArgumentError FHIRClient.request_raw(
+            @test_throws ArgumentError FHIRClient._request_raw(
                 client2,
                 "GET",
                 path;
@@ -112,7 +112,7 @@
                 require_base_url = sym,
             )
         end
-        @test FHIRClient.request_raw(client2, "GET", path; require_base_url = :no) ==
+        @test FHIRClient._request_raw(client2, "GET", path; require_base_url = :no) ==
               raw_response
         @test FHIRClient.request_json(client2, "GET", path; require_base_url = :no) ==
               json_response
@@ -122,11 +122,11 @@
         # Mismatch of host
         base_url2 = FHIRClient.BaseURL(URIs.URI(base_url.uri; host = "example.com"))
         client2 = FHIRClient.Client(fhir_version, base_url2, auth)
-        @test_throws ArgumentError FHIRClient.request_raw(client2, "GET", path)
+        @test_throws ArgumentError FHIRClient._request_raw(client2, "GET", path)
         @test_throws ArgumentError FHIRClient.request_json(client2, "GET", path)
         @test_throws ArgumentError FHIRClient.request(Dict, client2, "GET", path)
         for sym in (:strict, :host)
-            @test_throws ArgumentError FHIRClient.request_raw(
+            @test_throws ArgumentError FHIRClient._request_raw(
                 client2,
                 "GET",
                 path;
@@ -147,7 +147,7 @@
             )
         end
         for sym in (:scheme, :no)
-            @test FHIRClient.request_raw(client2, "GET", path; require_base_url = sym) ==
+            @test FHIRClient._request_raw(client2, "GET", path; require_base_url = sym) ==
                   raw_response
             @test FHIRClient.request_json(client2, "GET", path; require_base_url = sym) ==
                   json_response
@@ -160,10 +160,10 @@
             URIs.URI(base_url.uri; path = replace(base_url.uri.path, "/r4" => "/baseR4")),
         )
         client2 = FHIRClient.Client(fhir_version, base_url2, auth)
-        @test_throws ArgumentError FHIRClient.request_raw(client2, "GET", path)
+        @test_throws ArgumentError FHIRClient._request_raw(client2, "GET", path)
         @test_throws ArgumentError FHIRClient.request_json(client2, "GET", path)
         @test_throws ArgumentError FHIRClient.request(Dict, client2, "GET", path)
-        @test_throws ArgumentError FHIRClient.request_raw(
+        @test_throws ArgumentError FHIRClient._request_raw(
             client2,
             "GET",
             path;
@@ -183,7 +183,7 @@
             require_base_url = :strict,
         )
         for sym in (:host, :scheme, :no)
-            @test FHIRClient.request_raw(client2, "GET", path; require_base_url = sym) ==
+            @test FHIRClient._request_raw(client2, "GET", path; require_base_url = sym) ==
                   raw_response
             @test FHIRClient.request_json(client2, "GET", path; require_base_url = sym) ==
                   json_response
@@ -192,16 +192,16 @@
         end
 
         # Other keyword arguments
-        @test FHIRClient.request_raw(client, "GET", patient_request) == raw_response
-        @test FHIRClient.request_raw(client, "GET", patient_request; body = "{}") ==
+        @test FHIRClient._request_raw(client, "GET", patient_request) == raw_response
+        @test FHIRClient._request_raw(client, "GET", patient_request; body = "{}") ==
               raw_response
-        @test FHIRClient.request_raw(
+        @test FHIRClient._request_raw(
             client,
             "GET",
             patient_request;
             query = Dict{String,String}(),
         ) == raw_response
-        @test FHIRClient.request_raw(
+        @test FHIRClient._request_raw(
             client,
             "GET",
             patient_request;

--- a/test/integration/json.jl
+++ b/test/integration/json.jl
@@ -11,8 +11,8 @@
 
         patient_id = json_response_search_results_bundle.entry[1].resource.id
         patient_request = "/Patient/$(patient_id)"
-        raw_response = FHIRClient.request_raw(client, "GET", patient_request)
-        @test raw_response isa String
+        raw_response = @inferred(FHIRClient.request_raw(client, "GET", patient_request))
+        @test raw_response isa Vector{UInt8}
 
         # `request_json` and `request` yield consistent results
         json_response = FHIRClient.request_json(client, "GET", patient_request)

--- a/test/integration/json.jl
+++ b/test/integration/json.jl
@@ -37,8 +37,12 @@
         for path in ("Patient/$(patient_id)", "./Patient/$(patient_id)")
             # For relative paths the `require_base_url` setting does not matter
             for sym in (:strict, :host, :scheme, :no)
-                @test FHIRClient._request_raw(client, "GET", path; require_base_url = sym) ==
-                      raw_response
+                @test FHIRClient._request_raw(
+                    client,
+                    "GET",
+                    path;
+                    require_base_url = sym,
+                ) == raw_response
                 @test FHIRClient.request_json(
                     client,
                     "GET",

--- a/test/unit/requests.jl
+++ b/test/unit/requests.jl
@@ -56,13 +56,13 @@
     @testset "tryparse_json" begin
         for json_body in ("42", "{}", "{\"firstName\":\"John\", \"lastName\":\"Doe\"}")
             @test (@test_logs min_level = Logging.Debug FHIRClient.tryparse_json(
-                json_body,
+                codeunits(json_body),
             )) == JSON3.read(json_body)
         end
         for no_json_body in ("{3}", "[ 4 }", "{\"firstName\":John}")
             logger = Test.TestLogger(; min_level = Logging.Debug)
             res = Logging.with_logger(logger) do
-                FHIRClient.tryparse_json(no_json_body)
+                FHIRClient.tryparse_json(codeunits(no_json_body))
             end
             @test res === nothing
             log = only(logger.logs)


### PR DESCRIPTION
This is a somewhat random thought: Maybe it would be clearer that `request_raw` is very low-level (and possibly not what users or downstream developers should typically use) if it would return the raw response body from HTTP.jl, i.e., a `Vector{UInt8}`, instead of a `String` (as done currently by converting the byte vector to a `String`).

Additionally, since `JSON3.read` can operate on `Vector{UInt8}` it would be possible to avoid the `String` conversion also in `request_json` and `request`.

Technically this change is breaking even though it only concerns `request_raw`...