### PR TITLE
Allow nightly test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
     needs: format
     name: Julia ${{ matrix.version }} / generate=${{ matrix.generate }} / ${{ matrix.os }} / ${{ matrix.arch }} / ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Currently, tests fail with Julia nightly and therefore the CI reports a failing status (see e.g. #162). With this PR nightly test failures won't affect the status of CI.